### PR TITLE
Multiplex

### DIFF
--- a/generator/CANlib_c.py
+++ b/generator/CANlib_c.py
@@ -102,7 +102,7 @@ def write(can, output_path=can_lib_c_path, base_path=can_lib_c_base_path):
                     '\t' * (num_tabs + 1) + 'switch(key) {' '\n'
                 )
 
-                name_prepends = '_'.join([name_prepends, frame.name])
+                name_prepends += '_' + frame.name
 
                 for sub_frame in frame.frame:
                     if isinstance(sub_frame, ParseCAN.spec.bus.MultiplexedFrame):

--- a/generator/CANlib_c.py
+++ b/generator/CANlib_c.py
@@ -89,17 +89,17 @@ def write(can, output_path=can_lib_c_path, base_path=can_lib_c_base_path):
 
             def single_handler(frame, name_prepends, num_tabs):
                 fw(
-                    '\t' * num_tabs + 'case {}_key'.format(coord(name_prepends, frame.name)) + '\n' +
+                    '\t' * num_tabs + 'case {}_key:'.format(coord(name_prepends, frame.name)) + '\n' +
                     '\t' * (num_tabs + 1) + 'return {};\n'.format(coord(name_prepends, frame.name))
                 )
 
             def multplxd_handler(frame, name_prepends, num_tabs):
                 fw('\t' * num_tabs + 'case {}_key:\n'.format(coord(name_prepends, frame.name)))
                 key_size = ceil(frame.slice.length / 8) * 8
+                key_name = '_'.join([name_prepends,frame.name, 'key'])
                 fw('\t' * (num_tabs + 1) + 'to_bitstring(frame->data, &bitstring);' '\n')
                 fw(
-                    '\t' * (num_tabs + 1) + 'uint{}_t key = EXTRACT(bitstring, {}, {});\n'.format(key_size, frame.slice.start, frame.slice.length) +
-                    '\t' * (num_tabs + 1) + 'switch(key) {' '\n'
+                    '\t' * (num_tabs + 1) + 'uint{}_t {} = EXTRACT(bitstring, {}, {});\n'.format(key_size, key_name, frame.slice.start, frame.slice.length) + '\t' * (num_tabs + 1) + 'switch(' + key_name + ') {' '\n'
                 )
 
                 name_prepends += '_' + frame.name

--- a/generator/CANlib_c.py
+++ b/generator/CANlib_c.py
@@ -83,6 +83,7 @@ def write(can, output_path=can_lib_c_path, base_path=can_lib_c_base_path):
             # Write switch statement
             fw((
                 '{}_T CANlib_Identify_{}(Frame* frame)'.format(coord(bus.name), coord(bus.name, prefix=False)) + '{' '\n'
+                '\t' 'uint64_t bitstring = 0;' '\n'
                 '\t' 'switch(frame->id) {' '\n'
             ))
 
@@ -91,7 +92,6 @@ def write(can, output_path=can_lib_c_path, base_path=can_lib_c_base_path):
                 if isinstance(msg, ParseCAN.spec.bus.MultiplexedFrame):
                     key_size = ceil(msg.slice.length / 8) * 8
                     fw(
-                        '\t' '\t' '\t' 'uint64_t bistring = 0;' '\n'
                         '\t' '\t' '\t' 'to_bitstring(frame->data, &bitstring);' '\n'
                     )
 
@@ -230,4 +230,8 @@ def write(can, output_path=can_lib_c_path, base_path=can_lib_c_base_path):
         # Write DEFINE statements
         for bus in can.bus:
             for msg in bus.frame:
-                fw('DEFINE(' + coord(bus.name, msg.name, prefix=False) + ')\n')
+                if isinstance(msg, ParseCAN.spec.bus.MultiplexedFrame):
+                    for frame in msg.frame:
+                            fw('DEFINE(' + coord(bus.name, msg.name, frame.name, prefix=False) + ')\n')
+                else:
+                    fw('DEFINE(' + coord(bus.name, msg.name, prefix=False) + ')\n')

--- a/generator/CANlib_h.py
+++ b/generator/CANlib_h.py
@@ -49,14 +49,22 @@ def write(can, output_path=can_lib_h_path):
         for bus in can.bus:
             fw('typedef enum {\n')
 
+            # First frame needs to start at 2, the rest will follow
+            first_frame = True
             for msg in bus.frame:
                 if isinstance(msg, ParseCAN.spec.bus.MultiplexedFrame):
                     for frame in msg.frame:
-                        fw(templ['enum'].format(coord(bus.name, msg.name, frame.name), idx))
-                        idx += 1
+                        fw('\t' + coord(bus.name, msg.name, frame.name))
+                        if first_frame:
+                            fw(' = 2')
+                        first_frame = False
+                        fw(',\n')
                 else:
-                    fw(templ['enum'].format(coord(bus.name, msg.name), idx))
-                    idx += 1
+                    fw('\t' + coord(bus.name, msg.name))
+                    if first_frame:
+                        fw(' = 2')
+                    first_frame = False
+                    fw(',\n')
 
             fw('} ' + '{}_T;\n\n'.format(coord(bus.name)))
 

--- a/generator/CANlib_h.py
+++ b/generator/CANlib_h.py
@@ -60,7 +60,11 @@ def write(can, output_path=can_lib_h_path):
         # Write DECLARE statements
         for bus in can.bus:
             for msg in bus.frame:
-                fw('DECLARE({})\n'.format(coord(bus.name, msg.name, prefix=False)))
+                if isinstance(msg, ParseCAN.spec.bus.MultiplexedFrame):
+                    for frame in msg.frame:
+                        fw('DECLARE({})\n'.format(coord(bus.name, msg.name, frame.name, prefix=False)))
+                else:
+                    fw('DECLARE({})\n'.format(coord(bus.name, msg.name, prefix=False)))
 
         fw('\n')
 

--- a/generator/CANlib_h.py
+++ b/generator/CANlib_h.py
@@ -51,7 +51,7 @@ def write(can, output_path=can_lib_h_path):
 
             for msg in bus.frame:
                 if isinstance(msg, ParseCAN.spec.bus.MultiplexedFrame):
-                    for frame in msg. frame:
+                    for frame in msg.frame:
                         fw(templ['enum'].format(coord(bus.name, msg.name, frame.name), idx))
                         idx += 1
                 else:

--- a/generator/CANlib_h.py
+++ b/generator/CANlib_h.py
@@ -50,12 +50,17 @@ def write(can, output_path=can_lib_h_path):
             fw('typedef enum {\n')
 
             for msg in bus.frame:
-                fw(templ['enum'].format(coord(bus.name, msg.name), idx))
-                idx += 1
+                if isinstance(msg, ParseCAN.spec.bus.MultiplexedFrame):
+                    for frame in msg. frame:
+                        fw(templ['enum'].format(coord(bus.name, msg.name, frame.name), idx))
+                        idx += 1
+                else:
+                    fw(templ['enum'].format(coord(bus.name, msg.name), idx))
+                    idx += 1
 
             fw('} ' + '{}_T;\n\n'.format(coord(bus.name)))
 
-            fw('{}_T CANlib_Identify_{}(Frame* frame);'.format(coord(bus.name), coord(bus.name, prefix=False)) + '\n')
+            fw('{}_T CANlib_Identify_{}(Frame* frame);'.format(coord(bus.name), coord(bus.name, prefix=False)) + '\n\n')
 
         # Write DECLARE statements
         for bus in can.bus:

--- a/generator/constants.py
+++ b/generator/constants.py
@@ -36,16 +36,10 @@ def write(can, output_path=constants_path):
                 for msg in bus.frame:
                     if isinstance(msg, ParseCAN.spec.bus.MultiplexedFrame):
                         for frame in msg.frame:
-                            try:
-                                attr = transform(getattr(frame, attrnm))
-                                fw(templ[form].format(coord(bus.name, msg.name, frame.name, finalnm), attr))
-                            except AttributeError:
-                                pass
-                    try:
-                        attr = transform(getattr(msg, attrnm))
-                        fw(templ[form].format(coord(bus.name, msg.name, finalnm), attr))
-                    except AttributeError:
-                        pass
+                            attr = transform(getattr(frame, attrnm))
+                            fw(templ[form].format(coord(bus.name, msg.name, frame.name, finalnm), attr))
+                    attr = transform(getattr(msg, attrnm))
+                    fw(templ[form].format(coord(bus.name, msg.name, finalnm), attr))
 
         fw(endif(header_name))
 

--- a/generator/constants.py
+++ b/generator/constants.py
@@ -41,12 +41,11 @@ def write(can, output_path=constants_path):
                                 fw(templ[form].format(coord(bus.name, msg.name, frame.name, finalnm), attr))
                             except AttributeError:
                                 pass
-                    else:
-                        try:
-                            attr = transform(getattr(msg, attrnm))
-                            fw(templ[form].format(coord(bus.name, msg.name, finalnm), attr))
-                        except AttributeError:
-                            pass
+                    try:
+                        attr = transform(getattr(msg, attrnm))
+                        fw(templ[form].format(coord(bus.name, msg.name, finalnm), attr))
+                    except AttributeError:
+                        pass
 
         fw(endif(header_name))
 

--- a/generator/enum_atom.py
+++ b/generator/enum_atom.py
@@ -28,7 +28,22 @@ def write(can, output_path=enum_atom_path):
         for bus in can.bus:
             for msg in bus.frame:
                 if isinstance(msg, ParseCAN.spec.bus.MultiplexedFrame):
-                    print("Multiplexed frame, skipping!")
+                    for frame in msg.frame:
+                        for atom in frame.atom:
+                            if atom.type.isenum():
+                                # Only C++11 feature
+                                # fw('typedef enum ' + (atom.type.type + ' ' if atom.type.type else '') + '{\n')
+
+                                fw('typedef enum {\n')
+
+                                for enum in atom.type.enum:
+                                    fw(templ['enum'].format(
+                                        coord(bus.name, msg.name, atom.name, enum.name),
+                                        enum.value
+                                    ))
+
+                                fw('} ' + '{}_T;\n\n'.format(coord(bus.name, msg.name, atom.name)))
+
                 else:
                     for atom in msg.atom:
                         if atom.type.isenum():

--- a/generator/enum_atom.py
+++ b/generator/enum_atom.py
@@ -27,19 +27,22 @@ def write(can, output_path=enum_atom_path):
 
         for bus in can.bus:
             for msg in bus.frame:
-                for atom in msg.atom:
-                    if atom.type.isenum():
-                        # Only C++11 feature
-                        # fw('typedef enum ' + (atom.type.type + ' ' if atom.type.type else '') + '{\n')
+                if isinstance(msg, ParseCAN.spec.bus.MultiplexedFrame):
+                    print("Multiplexed frame, skipping!")
+                else:
+                    for atom in msg.atom:
+                        if atom.type.isenum():
+                            # Only C++11 feature
+                            # fw('typedef enum ' + (atom.type.type + ' ' if atom.type.type else '') + '{\n')
 
-                        fw('typedef enum {\n')
+                            fw('typedef enum {\n')
 
-                        for enum in atom.type.enum:
-                            fw(templ['enum'].format(
-                                coord(bus.name, msg.name, atom.name, enum.name),
-                                enum.value
-                            ))
+                            for enum in atom.type.enum:
+                                fw(templ['enum'].format(
+                                    coord(bus.name, msg.name, atom.name, enum.name),
+                                    enum.value
+                                ))
 
-                        fw('} ' + '{}_T;\n\n'.format(coord(bus.name, msg.name, atom.name)))
+                            fw('} ' + '{}_T;\n\n'.format(coord(bus.name, msg.name, atom.name)))
 
         fw(endif(header_name))

--- a/generator/structs.py
+++ b/generator/structs.py
@@ -30,13 +30,16 @@ def write(can, output_path=structs_path):
             for msg in bus.frame:
                 fw('typedef struct {\n')
 
-                for atom in msg.atom:
-                    if atom.type.isenum():
-                        enum_name = coord(bus.name, msg.name, atom.name) + '_T'
-                        fw('\t{} {};\n'.format(enum_name, atom.name))
-                    else:
-                        fw('\t{} {};\n'.format(atom.type.ctype(), atom.name))
+                if isinstance(msg, ParseCAN.spec.bus.MultiplexedFrame):
+                    print("Multiplexed frame, skipping!")
+                else:
+                    for atom in msg.atom:
+                        if atom.type.isenum():
+                            enum_name = coord(bus.name, msg.name, atom.name) + '_T'
+                            fw('\t{} {};\n'.format(enum_name, atom.name))
+                        else:
+                            fw('\t{} {};\n'.format(atom.type.ctype(), atom.name))
 
-                fw('} ' + '{}_T;\n\n'.format(coord(bus.name, msg.name)))
+                    fw('} ' + '{}_T;\n\n'.format(coord(bus.name, msg.name)))
 
         fw(endif(header_name))

--- a/generator/structs.py
+++ b/generator/structs.py
@@ -8,6 +8,25 @@ sys.path.append('ParseCAN')
 import ParseCAN
 from common import structs_path, coord, ifndef, endif
 
+def process_single(fw, frame, prefix):
+    """
+    Helper function to avoid duplicate code between multiplexed
+    and single frames.
+
+    :param fw: file writer
+    :param frame: frame to write
+    :prefix: bus name for single frames, bus name + top level name for
+             Multiplexed
+    """
+    for atom in frame.atom:
+        if atom.type.isenum():
+            enum_name = coord(prefix, frame.name, atom.name) + '_T'
+            fw('\t{} {};\n'.format(enum_name, atom.name))
+        else:
+            fw('\t{} {};\n'.format(atom.type.ctype(), atom.name))
+
+    fw('} ' + '{}_T;\n\n'.format(coord(prefix, frame.name)))
+
 def write(can, output_path=structs_path):
     '''
     Write the header files for the main structs in the library.
@@ -31,15 +50,8 @@ def write(can, output_path=structs_path):
                 fw('typedef struct {\n')
 
                 if isinstance(msg, ParseCAN.spec.bus.MultiplexedFrame):
-                    print("Multiplexed frame, skipping!")
+                    for frame in msg.frame:
+                        process_single(fw, frame, bus.name + "_" + msg.name)
                 else:
-                    for atom in msg.atom:
-                        if atom.type.isenum():
-                            enum_name = coord(bus.name, msg.name, atom.name) + '_T'
-                            fw('\t{} {};\n'.format(enum_name, atom.name))
-                        else:
-                            fw('\t{} {};\n'.format(atom.type.ctype(), atom.name))
-
-                    fw('} ' + '{}_T;\n\n'.format(coord(bus.name, msg.name)))
-
+                    process_single(fw, msg, bus.name)
         fw(endif(header_name))


### PR DESCRIPTION
A lot of this is involves some duplicated code--it might be nice to add something to ParseCan for a way to grab all types of messages, with multiplexed messages mixed in with standard messages and the upper level message name appended on and the key available as a standard message. But this should produce correct code