### PR TITLE
Vcu logging

### DIFF
--- a/generator/computers_c.py
+++ b/generator/computers_c.py
@@ -130,5 +130,5 @@ def write(can, computers, output_path=computer_c_dir_path):
                     '\t\t\tCANlib_HandleFrame_{}(frame);\n'.format(bus) +
                     '\t\t\tbreak;\n'
                 )
-            fw('\t\tdefault:\n\t\t\tbreak;\n')
+            fw('\t\tdefault:\n\t\t\tUNUSED(frame);\n\t\tbreak;\n')
             fw('\t}\n}\n')

--- a/src/drivers/src/stm32f4xx.c
+++ b/src/drivers/src/stm32f4xx.c
@@ -39,7 +39,9 @@ HAL_StatusTypeDef CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus) {
   pHeader.IDE = frame->extended ? CAN_ID_EXT: CAN_ID_STD;
   pHeader.RTR = CAN_RTR_DATA; // Data frame (as opposed to a remote frame)
   pHeader.TransmitGlobalTime = DISABLE; // Don't replace last 2 bytes of data with TX time.
+#ifdef USING_LOGGING_CALLBACK
   log_frame(frame, bus_num);
+#endif
   return HAL_CAN_AddTxMessage(hcan, &pHeader, frame->data, &pTxMailbox);
 }
 

--- a/src/drivers/src/stm32f4xx.c
+++ b/src/drivers/src/stm32f4xx.c
@@ -41,6 +41,8 @@ HAL_StatusTypeDef CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus) {
   pHeader.TransmitGlobalTime = DISABLE; // Don't replace last 2 bytes of data with TX time.
 #ifdef USING_LOGGING_CALLBACK
   log_frame(frame, bus_num);
+#else
+  UNUSED(bus_num);
 #endif
   return HAL_CAN_AddTxMessage(hcan, &pHeader, frame->data, &pTxMailbox);
 }

--- a/src/drivers/src/stm32f4xx.c
+++ b/src/drivers/src/stm32f4xx.c
@@ -12,16 +12,20 @@ extern CAN_HandleTypeDef hcan3;
 
 HAL_StatusTypeDef CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus) {
   CAN_Raw_Bus_T raw_bus = CANlib_GetRawBus(bus);
+  int bus_num;
   CAN_HandleTypeDef* hcan;
   switch(raw_bus) {
     case CAN_1:
       hcan = &hcan1;
+      bus_num = 1;
       break;
     case CAN_2:
       hcan = &hcan2;
+      bus_num = 2;
       break;
     case CAN_3:
       hcan = &hcan3;
+      bus_num = 3;
       break;
     default:
       return HAL_ERROR;
@@ -35,6 +39,7 @@ HAL_StatusTypeDef CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus) {
   pHeader.IDE = frame->extended ? CAN_ID_EXT: CAN_ID_STD;
   pHeader.RTR = CAN_RTR_DATA; // Data frame (as opposed to a remote frame)
   pHeader.TransmitGlobalTime = DISABLE; // Don't replace last 2 bytes of data with TX time.
+  log_frame(frame, bus_num);
   return HAL_CAN_AddTxMessage(hcan, &pHeader, frame->data, &pTxMailbox);
 }
 


### PR DESCRIPTION
The `computers_c.py` change is just to fix a warnings problem I came across while testing this with sensor-node (which was just a "does this compile without the logging flag for other boards" check). The other part is to add a logging callback.