### PR TITLE
Fix driver selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ If you're cloning this for the first time, use `git clone --recursive` to pull a
 
 To generate this library, run `main.py` in the `generator` directory with the path to your CAN spec as an argument (e.g. `python main.py ../../../can_spec_my18.yml` if you're running this from the `lib` directory in MY18). Make sure to use Python 3. This generates all of the necessary source files that are listed in `.gitignore`. These files are dependent on the CAN spec. If you want to change one of these files, don't edit them directly, but instead figure out what needs to change in the CAN spec. (If that still doesn't work, edit the generator scripts in `generator` rather than the generated files.) Source files that aren't ignored aren't generated from the CAN spec, so they can be edited directly.
 
-When compiling, you need to compile with the appropriate `CANLIB_ARCH` defined in order to use the appropriate driver.
+When compiling, you need to compile with the appropriate `CANLIB_ARCH_` defined in order to use the appropriate driver.  Included drivers are listed in `driver.h`.
 
 ## Writing a CAN spec
 The CAN spec should be a YAML file with the following structure:

--- a/src/driver.h
+++ b/src/driver.h
@@ -2,16 +2,11 @@
 
 // INCLUDE THIS AFTER YOUR DRIVER
 
-#ifndef CANLIB_ARCH
-#error "No architecture specified!"
-#endif
-
-#if CANLIB_ARCH == STM32F4xx
+#ifdef CANLIB_ARCH_STM32F4xx
 #include "drivers/inc/stm32f4xx.h"
-#elif CANLIB_ARCH == STM32F2xx
+#elif defined(CANLIB_ARCH_STM32F2XX)
 #include "drivers/inc/stm32f2xx.h"
-#else
-#error "Architecture not supported!"
+#error "No architecture specified!"
 #endif
 
 #include "bus.h"

--- a/src/driver.h
+++ b/src/driver.h
@@ -4,7 +4,7 @@
 
 #ifdef CANLIB_ARCH_STM32F4xx
 #include "drivers/inc/stm32f4xx.h"
-#elif defined(CANLIB_ARCH_STM32F2XX)
+#elif defined(CANLIB_ARCH_STM32F2xx)
 #include "drivers/inc/stm32f2xx.h"
 #error "No valid architecture specified!"
 #endif

--- a/src/driver.h
+++ b/src/driver.h
@@ -6,7 +6,7 @@
 #include "drivers/inc/stm32f4xx.h"
 #elif defined(CANLIB_ARCH_STM32F2XX)
 #include "drivers/inc/stm32f2xx.h"
-#error "No architecture specified!"
+#error "No valid architecture specified!"
 #endif
 
 #include "bus.h"


### PR DESCRIPTION
Note that this breaks any current users of CANlib without them setting the defines correctly.

This fix is already included in @reality95's pull request, but I'd like to merge this in first for the inverter. 

Should be noted that this resolves #21. 