### PR TITLE
Add STM32H7xx driver

### DIFF
--- a/src/driver.h
+++ b/src/driver.h
@@ -3,7 +3,7 @@
 
 // INCLUDE THIS AFTER YOUR DRIVER
 
-#include "drivers/inc/stm32f4xx.h"  // BAD HACK
+#include "drivers/inc/stm32h7xx.h"
 #include "bus.h"
 
 CANlib_Transmit_Error_T CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus);

--- a/src/drivers/inc_template/stm32h7xx.h
+++ b/src/drivers/inc_template/stm32h7xx.h
@@ -1,0 +1,27 @@
+#ifndef __STM32H7XX_CAN_H
+#define __STM32H7XX_CAN_H
+
+#include "static.h"
+#include "stm32h7xx_hal.h"
+#include "bus.h"
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// BUILD CAN_Raw_Bus_T
+
+typedef uint32_t Time_T; // in ms
+typedef HAL_StatusTypeDef CANlib_Transmit_Error_T;
+typedef HAL_StatusTypeDef CANlib_Init_Error_T;
+
+CANlib_Transmit_Error_T CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus);
+void CANlib_ReadFrame(Frame *frame, CANlib_Bus_T bus);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+#endif // __STM32H7XX_CAN_H

--- a/src/drivers/src/stm32f4xx.c
+++ b/src/drivers/src/stm32f4xx.c
@@ -68,15 +68,12 @@ void CANlib_ReadFrame(Frame *frame, CANlib_Bus_T bus) {
       return;
   }
 
-  uint8_t data[8] = {};
   CAN_RxHeaderTypeDef pHeader;
   for (int fifo = 0; fifo < 2; fifo++) {  // There are 2 receive FIFOs
     if (HAL_CAN_GetRxFifoFillLevel(hcan, fifo) > 0) {
-      HAL_CAN_GetRxMessage(hcan, fifo, &pHeader, data);
+      HAL_CAN_GetRxMessage(hcan, fifo, &pHeader, frame->data);
       frame->id  = pHeader.IDE == CAN_ID_STD ? pHeader.StdId : pHeader.ExtId;
       frame->dlc = pHeader.DLC;
-
-      memcpy(frame->data, data, sizeof(data));
       frame->extended = pHeader.IDE == CAN_ID_EXT;
       return;
     }

--- a/src/drivers/src/stm32h7xx.c
+++ b/src/drivers/src/stm32h7xx.c
@@ -1,0 +1,84 @@
+#include "static.h"
+
+#include "drivers/inc/stm32h7xx.h"
+#include "stm32h7xx_hal.h"
+#include "bus.h"
+#include "driver.h"
+#include <stdint.h>
+#include <string.h>
+#ifdef USING_LOGGING_CALLBACK
+  #include "log.h"
+#endif
+
+extern CAN_HandleTypeDef hcan1;
+extern CAN_HandleTypeDef hcan2;
+extern CAN_HandleTypeDef hcan3;
+
+HAL_StatusTypeDef CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus) {
+  CAN_Raw_Bus_T raw_bus = CANlib_GetRawBus(bus);
+  int bus_num;
+  CAN_HandleTypeDef* hcan;
+  switch(raw_bus) {
+    case CAN_1:
+      hcan = &hcan1;
+      bus_num = 1;
+      break;
+    case CAN_2:
+      hcan = &hcan2;
+      bus_num = 2;
+      break;
+    case CAN_3:
+      hcan = &hcan3;
+      bus_num = 3;
+      break;
+    default:
+      return HAL_ERROR;
+  }
+
+  CAN_TxHeaderTypeDef pHeader;
+  uint32_t pTxMailbox = 0;
+
+  pHeader.DLC = frame->dlc;
+  pHeader.StdId = frame->id;
+  pHeader.IDE = frame->extended ? CAN_ID_EXT: CAN_ID_STD;
+  pHeader.RTR = CAN_RTR_DATA; // Data frame (as opposed to a remote frame)
+  pHeader.TransmitGlobalTime = DISABLE; // Don't replace last 2 bytes of data with TX time.
+#ifdef USING_LOGGING_CALLBACK
+  log_frame(frame, bus_num);
+#else
+  UNUSED(bus_num);
+#endif
+  return HAL_FDCAN_AddMessageToTxBuffer(hcan, &pHeader, frame->data, &pTxMailbox);
+}
+
+void CANlib_ReadFrame(Frame *frame, CANlib_Bus_T bus) {
+  CAN_Raw_Bus_T raw_bus = CANlib_GetRawBus(bus);
+  CAN_HandleTypeDef *hcan;
+  switch(raw_bus) {
+    case CAN_1:
+      hcan = &hcan1;
+      break;
+    case CAN_2:
+      hcan = &hcan2;
+      break;
+    case CAN_3:
+      hcan = &hcan3;
+      break;
+    default:
+      return;
+  }
+
+  uint8_t data[8] = {};
+  CAN_RxHeaderTypeDef pHeader;
+  for (int fifo = 0; fifo < 2; fifo++) { // There are 2 receive FIFOs
+      if (HAL_FDCAN_GetRxFifoFillLevel(hcan, fifo) > 0) {
+        HAL_FDCAN_GetRxMessage(hcan, fifo, &pHeader, data);
+        frame->id = pHeader.IDE == CAN_ID_STD ? pHeader.StdId : pHeader.ExtId;
+        frame->dlc = pHeader.DLC;
+
+        memcpy(frame->data, data, sizeof(data));
+        frame->extended = pHeader.IDE == CAN_ID_EXT;
+        return;
+      }
+  }
+}

--- a/src/drivers/src/stm32h7xx.c
+++ b/src/drivers/src/stm32h7xx.c
@@ -40,8 +40,7 @@ HAL_StatusTypeDef CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus) {
 
   pHeader.DataLength = FDCAN_DLC_BYTES_8;
   //pHeader.DataLength = frame->dlc;
-  pHeader.Identifier= 0x333;
-  //pHeader.Identifier= frame->id;
+  pHeader.Identifier= frame->id;
   pHeader.IdType = frame->extended ? FDCAN_EXTENDED_ID: FDCAN_STANDARD_ID;
   pHeader.FDFormat =  FDCAN_CLASSIC_CAN;
   pHeader.TxFrameType = FDCAN_DATA_FRAME;

--- a/src/drivers/src/stm32h7xx.c
+++ b/src/drivers/src/stm32h7xx.c
@@ -38,6 +38,8 @@ HAL_StatusTypeDef CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus) {
 
   FDCAN_TxHeaderTypeDef pHeader;
 
+  pHeader.ErrorStateIndicator = 0;
+  pHeader.BitRateSwitch = 0;
   pHeader.DataLength = FDCAN_DLC_BYTES_8;
   //pHeader.DataLength = frame->dlc;
   pHeader.Identifier= frame->id;

--- a/src/drivers/src/stm32h7xx.c
+++ b/src/drivers/src/stm32h7xx.c
@@ -43,8 +43,8 @@ HAL_StatusTypeDef CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus) {
 
   FDCAN_TxHeaderTypeDef pHeader;
 
-  pHeader.ErrorStateIndicator = 0;
-  pHeader.BitRateSwitch = 0;
+  pHeader.ErrorStateIndicator = FDCAN_ESI_ACTIVE;
+  pHeader.BitRateSwitch = FDCAN_BRS_OFF;
   pHeader.Identifier= frame->id;
   pHeader.IdType = frame->extended ? FDCAN_EXTENDED_ID: FDCAN_STANDARD_ID;
   pHeader.FDFormat =  FDCAN_CLASSIC_CAN;

--- a/src/drivers/src/stm32h7xx.c
+++ b/src/drivers/src/stm32h7xx.c
@@ -78,18 +78,22 @@ void CANlib_ReadFrame(Frame *frame, CANlib_Bus_T bus) { CAN_Raw_Bus_T raw_bus = 
       return;
   }
 
+  // There are 2 receive FIFOs
+  // note that the macros are not equal to 0 and 1
   uint8_t data[8] = {};
   FDCAN_RxHeaderTypeDef pHeader;
-  for (int fifo = 0; fifo < 2; fifo++) { // There are 2 receive FIFOs
-      if (HAL_FDCAN_GetRxFifoFillLevel(hfdcan, fifo) > 0) {
-        HAL_FDCAN_GetRxMessage(hfdcan, fifo, &pHeader, data);
-        frame->id = pHeader.IdType == FDCAN_STANDARD_ID ? pHeader.Identifier: pHeader.Identifier;
-        FDCAN_def_to_size(pHeader.DataLength, &(frame->dlc));
+  uint32_t fifos[] = {FDCAN_RX_FIFO0, FDCAN_RX_FIFO1};
+  for (unsigned int i = 0; i < sizeof(fifos) / sizeof(fifos[0]); i++) {
+    uint32_t fifo = fifos[i];
+    if (HAL_FDCAN_GetRxFifoFillLevel(hfdcan, fifo) > 0) {
+      HAL_FDCAN_GetRxMessage(hfdcan, fifo, &pHeader, data);
+      frame->id = pHeader.IdType == FDCAN_STANDARD_ID ? pHeader.Identifier: pHeader.Identifier;
+      FDCAN_def_to_size(pHeader.DataLength, &(frame->dlc));
 
-        memcpy(frame->data, data, sizeof(data));
-        frame->extended = pHeader.IdType == FDCAN_EXTENDED_ID;
-        return;
-      }
+      memcpy(frame->data, data, sizeof(data));
+      frame->extended = pHeader.IdType == FDCAN_EXTENDED_ID;
+      return;
+    }
   }
 }
 

--- a/src/drivers/src/stm32h7xx.c
+++ b/src/drivers/src/stm32h7xx.c
@@ -87,7 +87,7 @@ void CANlib_ReadFrame(Frame *frame, CANlib_Bus_T bus) { CAN_Raw_Bus_T raw_bus = 
     uint32_t fifo = fifos[i];
     if (HAL_FDCAN_GetRxFifoFillLevel(hfdcan, fifo) > 0) {
       HAL_FDCAN_GetRxMessage(hfdcan, fifo, &pHeader, data);
-      frame->id = pHeader.IdType == FDCAN_STANDARD_ID ? pHeader.Identifier: pHeader.Identifier;
+      frame->id = pHeader.Identifier;
       FDCAN_def_to_size(pHeader.DataLength, &(frame->dlc));
 
       memcpy(frame->data, data, sizeof(data));

--- a/src/drivers/src/stm32h7xx.c
+++ b/src/drivers/src/stm32h7xx.c
@@ -80,17 +80,14 @@ void CANlib_ReadFrame(Frame *frame, CANlib_Bus_T bus) { CAN_Raw_Bus_T raw_bus = 
 
   // There are 2 receive FIFOs
   // note that the macros are not equal to 0 and 1
-  uint8_t data[8] = {};
   FDCAN_RxHeaderTypeDef pHeader;
   uint32_t fifos[] = {FDCAN_RX_FIFO0, FDCAN_RX_FIFO1};
   for (unsigned int i = 0; i < sizeof(fifos) / sizeof(fifos[0]); i++) {
     uint32_t fifo = fifos[i];
     if (HAL_FDCAN_GetRxFifoFillLevel(hfdcan, fifo) > 0) {
-      HAL_FDCAN_GetRxMessage(hfdcan, fifo, &pHeader, data);
+      HAL_FDCAN_GetRxMessage(hfdcan, fifo, &pHeader, frame->data);
       frame->id = pHeader.Identifier;
       FDCAN_def_to_size(pHeader.DataLength, &(frame->dlc));
-
-      memcpy(frame->data, data, sizeof(data));
       frame->extended = pHeader.IdType == FDCAN_EXTENDED_ID;
       return;
     }

--- a/src/drivers/src/stm32h7xx.c
+++ b/src/drivers/src/stm32h7xx.c
@@ -37,19 +37,21 @@ HAL_StatusTypeDef CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus) {
   }
 
   FDCAN_TxHeaderTypeDef pHeader;
-  uint32_t pTxMailbox = 0;
 
-  pHeader.DataLength = frame->dlc;
-  pHeader.Identifier= frame->id;
+  pHeader.DataLength = FDCAN_DLC_BYTES_8;
+  //pHeader.DataLength = frame->dlc;
+  pHeader.Identifier= 0x333;
+  //pHeader.Identifier= frame->id;
   pHeader.IdType = frame->extended ? FDCAN_EXTENDED_ID: FDCAN_STANDARD_ID;
-  //pHeader.RTR = CAN_RTR_DATA; // Data frame (as opposed to a remote frame)
+  pHeader.FDFormat =  FDCAN_CLASSIC_CAN;
+  pHeader.TxFrameType = FDCAN_DATA_FRAME;
   //pHeader.TransmitGlobalTime = DISABLE; // Don't replace last 2 bytes of data with TX time.
 #ifdef USING_LOGGING_CALLBACK
   log_frame(frame, bus_num);
 #else
   UNUSED(bus_num);
 #endif
-  return HAL_FDCAN_AddMessageToTxBuffer(hfdcan, &pHeader, frame->data, &pTxMailbox);
+  return HAL_FDCAN_AddMessageToTxFifoQ(hfdcan, &pHeader, frame->data);
 }
 
 void CANlib_ReadFrame(Frame *frame, CANlib_Bus_T bus) { CAN_Raw_Bus_T raw_bus = CANlib_GetRawBus(bus);

--- a/src/drivers/src/stm32h7xx.c
+++ b/src/drivers/src/stm32h7xx.c
@@ -10,25 +10,26 @@
   #include "log.h"
 #endif
 
-extern FDCAN_HandleTypeDef hcan1;
-extern FDCAN_HandleTypeDef hcan2;
-extern FDCAN_HandleTypeDef hcan3;
+extern FDCAN_HandleTypeDef hfdcan1;
+// TODO: do some macro crap to automatically deal with these if not used
+extern FDCAN_HandleTypeDef hfdcan2;
+extern FDCAN_HandleTypeDef hfdcan3;
 
 HAL_StatusTypeDef CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus) {
   CAN_Raw_Bus_T raw_bus = CANlib_GetRawBus(bus);
   int bus_num;
-  FDCAN_HandleTypeDef* hcan;
+  FDCAN_HandleTypeDef* hfdcan;
   switch(raw_bus) {
     case CAN_1:
-      hcan = &hcan1;
+      hfdcan = &hfdcan1;
       bus_num = 1;
       break;
     case CAN_2:
-      hcan = &hcan2;
+      hfdcan = &hfdcan2;
       bus_num = 2;
       break;
     case CAN_3:
-      hcan = &hcan3;
+      hfdcan = &hfdcan3;
       bus_num = 3;
       break;
     default:
@@ -48,20 +49,20 @@ HAL_StatusTypeDef CANlib_TransmitFrame(Frame *frame, CANlib_Bus_T bus) {
 #else
   UNUSED(bus_num);
 #endif
-  return HAL_FDCAN_AddMessageToTxBuffer(hcan, &pHeader, frame->data, &pTxMailbox);
+  return HAL_FDCAN_AddMessageToTxBuffer(hfdcan, &pHeader, frame->data, &pTxMailbox);
 }
 
 void CANlib_ReadFrame(Frame *frame, CANlib_Bus_T bus) { CAN_Raw_Bus_T raw_bus = CANlib_GetRawBus(bus);
-  FDCAN_HandleTypeDef *hcan;
+  FDCAN_HandleTypeDef *hfdcan;
   switch(raw_bus) {
     case CAN_1:
-      hcan = &hcan1;
+      hfdcan = &hfdcan1;
       break;
     case CAN_2:
-      hcan = &hcan2;
+      hfdcan = &hfdcan2;
       break;
     case CAN_3:
-      hcan = &hcan3;
+      hfdcan = &hfdcan3;
       break;
     default:
       return;
@@ -70,8 +71,8 @@ void CANlib_ReadFrame(Frame *frame, CANlib_Bus_T bus) { CAN_Raw_Bus_T raw_bus = 
   uint8_t data[8] = {};
   FDCAN_RxHeaderTypeDef pHeader;
   for (int fifo = 0; fifo < 2; fifo++) { // There are 2 receive FIFOs
-      if (HAL_FDCAN_GetRxFifoFillLevel(hcan, fifo) > 0) {
-        HAL_FDCAN_GetRxMessage(hcan, fifo, &pHeader, data);
+      if (HAL_FDCAN_GetRxFifoFillLevel(hfdcan, fifo) > 0) {
+        HAL_FDCAN_GetRxMessage(hfdcan, fifo, &pHeader, data);
         frame->id = pHeader.IdType == FDCAN_STANDARD_ID ? pHeader.Identifier: pHeader.Identifier;
         frame->dlc = pHeader.DataLength;
 


### PR DESCRIPTION
Adds STM32H7xx driver for inverter.  Based off the code that @Swissking1 wrote in the `rod-add-h7` branch, but fixed receiving messages, message sizes, and made to work with current CANlib code generation.  

I'd like Vedantha to test this code on the inverter before merging.  I'll add him to the organization and @ him here once I learn his public GitHub handle.  

Vedantha, switch your CANlib submodule to this branch and test the inverter.  You'll need to make some changes to `board.mk`:
Add `CANLIB_ARCH := $(shell echo $(MCU) | cut -c1-7)xx`
And add `-DCANLIB_ARCH="$(CANLIB_ARCH)" -DCANLIB_ARCH_$(CANLIB_ARCH)` to `COMMON_DEFS`